### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ h5py==2.9.0
 nltk==3.4.1
 numpy==1.16.3
 Pillow==6.0.0
-pkg-resources==0.0.0
 protobuf==3.7.1
 python-dateutil==2.8.0
 PyYAML==5.1


### PR DESCRIPTION
Delete the line "pkg-resources==0.0.0". This line seems from a bug of Ubuntu and would lead to an error when run "pip install -r requirements.txt".